### PR TITLE
Update workflow to not run build for draft PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,11 +5,13 @@ on:
     branches: [master, staging]
   pull_request:
     branches: [master, staging]
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     steps:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v13


### PR DESCRIPTION
Updates CI to not run the build while a PR is still a draft, then run the build normally when and after it becomes ready for review.

To test, I made this PR a draft and the build was skipped, and when I made it ready for review, the build was started